### PR TITLE
remove redundant dependency specifications

### DIFF
--- a/OpenFTTH.Schematic.Tests/OpenFTTH.Schematic.Tests.csproj
+++ b/OpenFTTH.Schematic.Tests/OpenFTTH.Schematic.Tests.csproj
@@ -10,12 +10,6 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="NetTopologySuite" Version="2.5.0" />
-    <PackageReference Include="OpenFTTH.Address.API" Version="2.1.0" />
-    <PackageReference Include="OpenFTTH.Address.Business" Version="2.1.0" />
-    <PackageReference Include="OpenFTTH.EventSourcing" Version="3.0.5" />
-    <PackageReference Include="OpenFTTH.RouteNetwork.API" Version="3.0.0" />
-    <PackageReference Include="OpenFTTH.RouteNetwork.Business" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.DependencyInjection" Version="8.3.0" />
     <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />


### PR DESCRIPTION
Removes redundant dependency specifications, they are already specified in the project referenced, and this is a testing library.

Removing it makes it easier to update dependencies in the future.